### PR TITLE
don't fail on users without signature(s)

### DIFF
--- a/webapp_admin/webapp_admin.py
+++ b/webapp_admin/webapp_admin.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from time import mktime
 import getpass
 import time
+import os
 from optparse import OptionGroup
 try:
     from dotty_dict import dotty
@@ -213,9 +214,9 @@ def backup_signature(user, location=None):
     except Exception as e:
         print('Could not load WebApp settings for user {} (Error: {})'.format(user.name, repr(e)))
         sys.exit(1)
-    if settings['settings']['zarafa']['v1']['contexts']['mail'].get('signatures'):
+    if type(settings['settings']['zarafa']['v1']['contexts']['mail']) is dict and settings['settings']['zarafa']['v1']['contexts']['mail'].get('signatures'):
         for item in settings['settings']['zarafa']['v1']['contexts']['mail']['signatures']['all']:
-            name = settings['settings']['zarafa']['v1']['contexts']['mail']['signatures']['all'][item]['name']
+            name = settings['settings']['zarafa']['v1']['contexts']['mail']['signatures']['all'][item]['name'].replace(os.path.sep, '_')
             filename = '%s/%s_%s_%s.html' % (backup_location, user.name, name.replace(' ', '-'), item)
             with open(filename, 'w') as outfile:
                 print('Dumping: \'{}\' to \'{}\' '.format(name, filename))


### PR DESCRIPTION
Signed-off-by: dmelha <dmelha@localhost>

extra check for type dict added because users without signature(s) can have a list object there.
example output without patch:
```
python3 webapp_admin.py.unpatched.py --all-users --backup --backup-signature
Creating backup WebApp settings for user kkopanocek
Dumping: 'Neue Signatur' to './kkopanocek_Neue-Signatur_1551091094578.html' 
konferenzraum: Has no or no valid WebApp settings creating empty config tree
Creating backup WebApp settings for user konferenzraum
konferenzraum: Has no or no valid WebApp settings creating empty config tree
user konferenzraum has no signature
Creating backup WebApp settings for user supertest100
Traceback (most recent call last):
  File "webapp_admin.py.unpatched.py", line 584, in <module>
    main()
  File "webapp_admin.py.unpatched.py", line 518, in main
    backup_signature(user, options.location)
  File "webapp_admin.py.unpatched.py", line 217, in backup_signature
    if settings['settings']['zarafa']['v1']['contexts']['mail'].get('signatures'):
AttributeError: 'list' object has no attribute 'get'
```