### PR TITLE
enhancement: don't fail if the user has no store or no recipients in store (yet)

### DIFF
--- a/manage_recipients/manage_recipients.py
+++ b/manage_recipients/manage_recipients.py
@@ -28,7 +28,17 @@ def main():
         sys.exit(0)
 
     user = kopano.Server(options).user(options.user)
-    webapp = user.store.prop(0X6773001F).value
+    
+    if user.store:
+      try:
+        webapp = user.store.prop(0X6773001F).value
+      except kopano.errors.NotFoundError as ke:
+        print("no such property for user(no stored recipients?). exiting")
+        sys.exit(0)
+    else:
+      print("user has no store. exiting")
+      sys.exit(0)
+    
     webapp = json.loads(webapp)
 
     if options.backup:

--- a/manage_recipients/manage_recipients.py
+++ b/manage_recipients/manage_recipients.py
@@ -32,8 +32,8 @@ def main():
     if user.store:
       try:
         webapp = user.store.prop(0X6773001F).value
-      except kopano.errors.NotFoundError as ke:
-        print("no such property for user(no stored recipients?). exiting")
+      except kopano.errors.NotFoundError:
+        print("no stored recipients in this store(no such property for user). exiting")
         sys.exit(0)
     else:
       print("user has no store. exiting")


### PR DESCRIPTION
make the script exit without error if requested user has no store yet or no recipients yet, instead of barfing out with an exception.